### PR TITLE
docs: update docs versions 9.3.4

### DIFF
--- a/libbeat/docs/version.asciidoc
+++ b/libbeat/docs/version.asciidoc
@@ -1,4 +1,4 @@
-:stack-version: 9.3.2
+:stack-version: 9.3.4
 :doc-branch: 9.3
 :go-version: 1.25.8
 :release-state: unreleased


### PR DESCRIPTION
Updates docs versions to 9.3.4.

Merge before the final Release build.