### PR TITLE
[Release] Update test environments for 9.3.4

### DIFF
--- a/testing/environments/latest.yml
+++ b/testing/environments/latest.yml
@@ -3,7 +3,7 @@
 version: '2.3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:9.3.3
     healthcheck:
       test: ["CMD-SHELL", "curl -s http://localhost:9200/_cat/health?h=status | grep -q green"]
       retries: 300
@@ -19,7 +19,7 @@ services:
       - "script.context.template.cache_max_size=2000"
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:9.3.2
+    image: docker.elastic.co/logstash/logstash:9.3.3
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:9600/_node/stats"]
       retries: 300
@@ -29,7 +29,7 @@ services:
       - ./docker/logstash/pki:/etc/pki:ro
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:9.3.2
+    image: docker.elastic.co/kibana/kibana:9.3.3
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5601"]
       retries: 300


### PR DESCRIPTION
Update test environment versions to the correct Elastic Stack version.

Merge only after the release of 9.3.3.